### PR TITLE
Performance - .net ReadAllLines instead of Import-CSV

### DIFF
--- a/Generate/run.ps1
+++ b/Generate/run.ps1
@@ -4,7 +4,7 @@ using namespace System.Net
 param($Request, $TriggerMetadata)
     $CharSet = ('0123456789{]+-[*=@:)}$^%;(_!&#?>/|').ToCharArray() 
     $RandSymbol = (Get-Random -InputObject $CharSet -count 5) -join ''
-    $words = Import-Csv wordlist.txt
+    $words = [System.IO.file]::ReadAllLines('wordlist.txt') 
     $Password = ($words |  get-random -count 3) + $RandSymbol -join ''
 
 # Associate values to output bindings by calling 'Push-OutputBinding'.


### PR DESCRIPTION
Hey @KelvinTegelaar, thank you for making this. 

Regarding the wordlist.txt loading, you can do things even faster !

**Iteration run 100 times**
![image](https://user-images.githubusercontent.com/1980296/96284424-8d564e80-0fab-11eb-858c-c54123af38e6.png)

Get-Content without the Raw parameter is notoriously slow.
Get-Content -Raw is very fast but converting it to a CSV after is just a tiny bit slower than Import-CSV

That being said, you don't have a csv, you have a list of string. 
Thus, you can use `Get-Content -Raw` (very fast) and split by lines. 

```
$words  =(Get-Content -Raw -Path .\wordlist.txt).split("`n")
```
For even better performance, you can use `.net` with 
```
$words = [System.IO.File]::ReadAllLines('wordlist.txt')
```


Here is what I used to calculate these results.

```
$Path = 'wordlist.txt'
$Iteration = 100

Write-Host "Get-Content as an array ".PadRight(30,' ') -NoNewline -ForegroundColor Cyan
$ms = Measure-Command {
    1..$Iteration | % {$words  =Get-Content -Path $Path} 
} | Select -ExpandProperty TotalMilliseconds 
Write-Host "($ms ms)"

Write-Host "Get-Content raw as CSV".PadRight(30,' ') -NoNewline -ForegroundColor Cyan
$ms = Measure-Command {
    1..$Iteration | % {$words  =Get-Content -Path $Path -Raw | ConvertFrom-Csv} 
} | Select -ExpandProperty TotalMilliseconds 
Write-Host "($ms ms)"

Write-Host "Import CSV".PadRight(30,' ') -NoNewline -ForegroundColor Cyan
$ms = Measure-Command {
    1..$Iteration | % {$words  =Import-Csv -Path $Path} 
} | Select -ExpandProperty TotalMilliseconds 
Write-Host "($ms ms)"

Write-Host "Get-Content -Raw + Split".PadRight(30,' ') -NoNewline -ForegroundColor Cyan
$ms = Measure-Command {
    1..$Iteration| % {$words  =(Get-Content -Raw -Path $Path).split("`n")} 
} | Select -ExpandProperty TotalMilliseconds 
Write-Host "($ms ms)"

Write-Host ".net ReadAllLines".PadRight(30,' ') -NoNewline -ForegroundColor Cyan
$ms = Measure-Command {
    1..$Iteration| % {
        $Words = [System.IO.file]::ReadAllLines($Path)
    } 
} | Select -ExpandProperty TotalMilliseconds 
Write-Host "($ms ms)"
```



