### PR TITLE
Feature/use guid as random

### DIFF
--- a/Create/run.ps1
+++ b/Create/run.ps1
@@ -11,7 +11,7 @@ if ($null -eq $Request.Query.Password) {
     $Password = ($Request.Query.Password)
 }
 $EncPassword = ($password | ConvertTo-SecureString -Force -AsPlainText) | ConvertFrom-SecureString
-$RandomID = get-random -Minimum 1 -Maximum 999999999999999
+$RandomID = (New-Guid).Guid.replace('-','')
 new-item "PasswordFile_$($randomid)" -Value ($encpassword) -force
 
 $URL = "https://$($Hostname)/Get?ID=$RandomID"


### PR DESCRIPTION
Just another tiny micro suggestion. 
Use a Guid instead of Random .

- Even less collision (36 X 16) than Get-Random  (10 X 15)
- ID always have 16 characters (Technically, with your Get-Random implementation, you can get low number ids like 1, 69, 420, 777, etc... 

